### PR TITLE
Let ConfigurationVersion support string versions

### DIFF
--- a/puppetreport/collector.go
+++ b/puppetreport/collector.go
@@ -20,7 +20,7 @@ var (
 	catalogVersionDesc = prometheus.NewDesc(
 		"puppet_last_catalog_version",
 		"The version of the last attempted Puppet catalog.",
-		nil,
+		[]string{"version"},
 		nil,
 	)
 
@@ -82,12 +82,12 @@ type Logger interface {
 type interpretedReport struct {
 	RunAt          float64
 	RunDuration    float64
-	CatalogVersion float64
+	CatalogVersion string
 	RunSuccess     float64
 }
 
 func (r interpretedReport) collect(ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(catalogVersionDesc, prometheus.GaugeValue, r.CatalogVersion)
+	ch <- prometheus.MustNewConstMetric(catalogVersionDesc, prometheus.UntypedValue, 0, r.CatalogVersion)
 	ch <- prometheus.MustNewConstMetric(runAtDesc, prometheus.GaugeValue, r.RunAt)
 	ch <- prometheus.MustNewConstMetric(runDurationDesc, prometheus.GaugeValue, r.RunDuration)
 	ch <- prometheus.MustNewConstMetric(runSuccessDesc, prometheus.GaugeValue, r.RunSuccess)

--- a/puppetreport/report.go
+++ b/puppetreport/report.go
@@ -24,7 +24,7 @@ import (
 )
 
 type runReport struct {
-	ConfigurationVersion float64                     `yaml:"configuration_version"`
+	ConfigurationVersion string                      `yaml:"configuration_version"`
 	Time                 time.Time                   `yaml:"time"`
 	TransactionCompleted bool                        `yaml:"transaction_completed"`
 	ReportFormat         int                         `yaml:"report_format"`

--- a/puppetreport/report_test.go
+++ b/puppetreport/report_test.go
@@ -26,7 +26,7 @@ func TestLoadReport(t *testing.T) {
 	expected := interpretedReport{
 		RunAt:          1618957125.5901103,
 		RunDuration:    17.199882286,
-		CatalogVersion: 1618957129,
+		CatalogVersion: "1618957129",
 		RunSuccess:     1,
 	}
 	if ir != expected {


### PR DESCRIPTION
Previous code assumed that the ConfigurationVeraion was only a number, but our versions are git hashes. Add the version as a label instead of a gauge instead.