### PR TITLE
chore(ci): Fix Renovate regexManager config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -14,7 +14,7 @@
         "^\\.github/workflows/go\\.yaml$"
       ],
       "matchStrings": [
-        "\\s+version: (?<currentValue>.*?) #(?<datasource>.*?): (?<lookupName>.*?)\\s"
+        "\\s+version: (?<currentValue>.*?) #(?<datasource>.*?): (?<depName>.*?)\\s"
       ]
     }
   ]


### PR DESCRIPTION
The capture group needs to be named `depName`.