### PR TITLE
chore(ci): Update Renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -6,7 +6,9 @@
     ":gitSignOff",
     "regexManagers:githubActionsVersions"
   ],
+  "platformAutomerge": true,
   "postUpdateOptions": [
-    "gomodTidy"
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
*   Enable use of platformAutomerge

*   Enable updating of go module import paths

    This should fix the case of the changed kingpin import, etc...