### PR TITLE
feat!: Report catalog version as a label

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ your environment that is discoverable by Prometheus.
 puppet_config{environment="",server="puppet.redacted"} 1
 # HELP puppet_last_catalog_version The version of the last attempted Puppet catalog.
 # TYPE puppet_last_catalog_version gauge
-puppet_last_catalog_version 1.618981114e+09
+puppet_last_catalog_version{version="1680640107"} 1
 # HELP puppet_last_run_at_seconds Time of the last Puppet run.
 # TYPE puppet_last_run_at_seconds gauge
-puppet_last_run_at_seconds 1.61898111071525e+09
+puppet_last_run_at_seconds 1.6806401024160552e+09
 # HELP puppet_last_run_duration_seconds Duration of the last Puppet run.
 # TYPE puppet_last_run_duration_seconds gauge
-puppet_last_run_duration_seconds 15.629926791
+puppet_last_run_duration_seconds 28.023470087
 # HELP puppet_last_run_success 1 if the last Puppet run was successful.
 # TYPE puppet_last_run_success gauge
 puppet_last_run_success 1
@@ -44,9 +44,6 @@ groups:
         for: 4h
       - alert: PuppetFailing
         expr: puppet_last_run_success == 0
-        for: 40m
-      - alert: StalePuppetCatalog
-        expr: time() - puppet_last_catalog_version > 3*60*60
         for: 40m
       - alert: LastPuppetTooLongAgo
         expr: time() - puppet_last_run_at_seconds > 3*60*60

--- a/puppetreport/collector.go
+++ b/puppetreport/collector.go
@@ -1,4 +1,4 @@
-// Copyright 2021 RetailNext, Inc.
+// Copyright 2023 RetailNext, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ var (
 	catalogVersionDesc = prometheus.NewDesc(
 		"puppet_last_catalog_version",
 		"The version of the last attempted Puppet catalog.",
-		nil,
+		[]string{"version"},
 		nil,
 	)
 
@@ -82,12 +82,12 @@ type Logger interface {
 type interpretedReport struct {
 	RunAt          float64
 	RunDuration    float64
-	CatalogVersion float64
+	CatalogVersion string
 	RunSuccess     float64
 }
 
 func (r interpretedReport) collect(ch chan<- prometheus.Metric) {
-	ch <- prometheus.MustNewConstMetric(catalogVersionDesc, prometheus.GaugeValue, r.CatalogVersion)
+	ch <- prometheus.MustNewConstMetric(catalogVersionDesc, prometheus.GaugeValue, 1, r.CatalogVersion)
 	ch <- prometheus.MustNewConstMetric(runAtDesc, prometheus.GaugeValue, r.RunAt)
 	ch <- prometheus.MustNewConstMetric(runDurationDesc, prometheus.GaugeValue, r.RunDuration)
 	ch <- prometheus.MustNewConstMetric(runSuccessDesc, prometheus.GaugeValue, r.RunSuccess)

--- a/puppetreport/report.go
+++ b/puppetreport/report.go
@@ -1,4 +1,4 @@
-// Copyright 2021 RetailNext, Inc.
+// Copyright 2023 RetailNext, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 )
 
 type runReport struct {
-	ConfigurationVersion float64                     `yaml:"configuration_version"`
+	ConfigurationVersion string                      `yaml:"configuration_version"`
 	Time                 time.Time                   `yaml:"time"`
 	TransactionCompleted bool                        `yaml:"transaction_completed"`
 	ReportFormat         int                         `yaml:"report_format"`

--- a/puppetreport/report_test.go
+++ b/puppetreport/report_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 RetailNext, Inc.
+// Copyright 2023 RetailNext, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ func TestLoadReport(t *testing.T) {
 	expected := interpretedReport{
 		RunAt:          1618957125.5901103,
 		RunDuration:    17.199882286,
-		CatalogVersion: 1618957129,
+		CatalogVersion: "1618957129",
 		RunSuccess:     1,
 	}
 	if ir != expected {


### PR DESCRIPTION
In order to accommodate environments where catalog versions are not numbers, `puppet_last_catalog_version` now reports a `version` label and always has a value of `1`.

This is a breaking change because it makes alerting on the staleness of the catalog version impossible, but in practice that alert was never useful. If you had the `StalePuppetCatalog` sample rule in your prometheus configuration, you should remove it before upgrading the exporter, in order to avoid false alerts caused by the value now being `1`.

Closes #60