### PR TITLE
chore: update renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,12 +1,34 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     ":semanticCommits",
     ":automergeAll",
     ":gitSignOff",
+    "customManagers:dockerfileVersions",
     "customManagers:githubActionsVersions"
   ],
-  "platformAutomerge": true,
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "groupName": "golang",
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "groupName": "golang",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "golang"
+      ]
+    }
+  ],
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"


### PR DESCRIPTION
Use the best-practices preset as a base and import other changes from RetailNext's internal defaults.