### PR TITLE
fix(ci): publish docker image with correct name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
 kos:
   - id: puppet-agent-exporter-ko
     build: puppet-agent-exporter-build
+    bare: true
     base_import_paths: true
     platforms:
       - linux/amd64


### PR DESCRIPTION
The previous goreleaser configuration caused ko to publish an image with a stuttered name at .../retailnext/puppet-agent-exporter/puppet-agent-exporter.