### PR TITLE
fix: run as root in the docker container

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ kos:
   - id: puppet-agent-exporter-ko
     build: puppet-agent-exporter-build
     bare: true
+    base_image: 'gcr.io/distroless/static-debian12'
     local_domain: "goreleaser.ko.local/puppet-agent-exporter"
     preserve_import_paths: false
     platforms:


### PR DESCRIPTION
We can revisit this later, but right now the docker container is useless because the last_run_report.yaml is owned by root with mode 0640.